### PR TITLE
Moved test idioms out of auto require

### DIFF
--- a/lib/idioms.rb
+++ b/lib/idioms.rb
@@ -1,4 +1,2 @@
 require "idioms/version"
 require "idioms/rack/catch_invalid_params"
-require "idioms/test/assertions"
-require "idioms/test/concurrently"

--- a/lib/idioms/test.rb
+++ b/lib/idioms/test.rb
@@ -1,0 +1,2 @@
+require "idioms/test/assertions"
+require "idioms/test/concurrently"


### PR DESCRIPTION
You must now explicitly require "idioms/test" to get the test helpers.
